### PR TITLE
Remove set -e from xcode.sh because it returns 1 in case of already present

### DIFF
--- a/xcode.sh
+++ b/xcode.sh
@@ -1,5 +1,3 @@
-set -e
-
 are_xcode_command_line_tools_installed() {
     xcode-select --print-path &> /dev/null
 }


### PR DESCRIPTION
Signed-off-by: Lou Marvin Caraig <loumarvincaraig@gmail.com>